### PR TITLE
removed use of popup.js in manifest.json::content_scripts. I think that was causing the 'SyntaxError: Cannot use import statement outside a module (at popup.js:3:1)'

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -2,3 +2,5 @@
 node_modules/
 dist/
 *.test.js
+*.html
+*.md

--- a/content.js
+++ b/content.js
@@ -1,27 +1,8 @@
-function extractTranscript() {
-  const transcriptLines = document.querySelectorAll('ytd-transcript-segment-renderer');
-  const transcriptArray = [];
-
-  transcriptLines.forEach((line) => {
-    const timestampElement = line.querySelector('.segment-timestamp');
-    const textElement = line.querySelector('.segment-text');
-
-    const timestamp = timestampElement ? timestampElement.innerText.trim() : '';
-    const words = textElement ? textElement.innerText.trim() : '';
-
-    if (timestamp && words) {
-      transcriptArray.push(`[${timestamp}] ${words}`);
-    }
-  });
-
-  // Join the array into a single block of text with newlines
-  return transcriptArray.join('\n');
-}
-
 // Listen for messages from the popup to send the transcript
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "getTranscript") {
-    const transcript = extractTranscript();
-    sendResponse({ transcript });
+    // Get video ID from current URL
+    const videoId = new URL(window.location.href).searchParams.get('v');
+    sendResponse({ videoId });
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
       "content_scripts": [
         {
           "matches": ["https://www.youtube.com/watch*"],
-          "js": ["popup/popup.js"]
+          "js": ["content.js"]
         }
       ],
       "permissions": [

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -2,7 +2,8 @@
 
 import LLM_API_Utils from './llm_api_utils.js';
 import StorageUtils from './storage_utils.js';
-import YoutubeTranscriptRetriever from './youtube_transcript_retrival.js'; // New import
+import YoutubeTranscriptRetriever from './youtube_transcript_retrival.js'; 
+
 
 // Declare the variables in a higher scope
 let transcriptDisplay, processedDisplay, prevBtn, nextBtn, segmentInfo, processBtn, loader, tabButtons, tabContents, modelSelect, transcriptInput, loadTranscriptBtn;


### PR DESCRIPTION
these turned out to be red herrings (b/c i get these errors too, but it still loads)

<img width="476" alt="Screenshot 2024-10-31 at 00 25 21" src="https://github.com/user-attachments/assets/1cc9a589-f3b5-428e-bc83-bd4480d27ca6">
